### PR TITLE
Added color correction nodes to composite

### DIFF
--- a/rct-graphics-helper/__init__.py
+++ b/rct-graphics-helper/__init__.py
@@ -24,7 +24,7 @@ bl_info = {
     "name": "RCT Graphics Helper",
     "description": "Render tool to replicate RCT graphics",
     "author": "Olivier Wervers",
-    "version": (0, 4, 6),
+    "version": (0, 6, 0),
     "blender": (2, 79, 0),
     "location": "Render",
     "support": "COMMUNITY",

--- a/rct-graphics-helper/builders/compositor_builder.py
+++ b/rct-graphics-helper/builders/compositor_builder.py
@@ -48,11 +48,28 @@ class CompositorBuilder(NodesBuilder):
         self.exit_branch_point()
 
         self.link(aa_mask, 0, combine_node, 3)
+        
+        #CurveRGB node
+        CurveRGB_composite_node = self.create_node("CompositorNodeCurveRGB")
+        curve_c = CurveRGB_composite_node.mapping.curves[3]
+        curve_c.points.new(.5,.5)
+        curve_c.points.new(.3,.2)
+        
+        self.link(mixed_anti_aliased, 0, CurveRGB_composite_node, 1)
+        
+        self.next_column()
+        
+        #HSV node
+        HueSat_composite_node = self.create_node("CompositorNodeHueSat")
+        HueSat_composite_node.inputs[2].default_value = 0.9
+        self.link(CurveRGB_composite_node, 0, HueSat_composite_node, 0)
+        
+        self.next_column()
 
         # Main output node
         output_composite_node = self.create_node("CompositorNodeComposite")
 
-        self.link(mixed_anti_aliased, 0, output_composite_node, 0)
+        self.link(HueSat_composite_node, 0, output_composite_node, 0)
         self.link(aa_mask, 0, output_composite_node, 1)
 
         # Metadata output node


### PR DESCRIPTION
This adds a color curve and a HSV node to the compositor.

An effort was made to refine the light-rig. The results where previously to "Flat" in comparison to their original references.
Adjusting the light values themselves introduced an imbalance in the allready good setup.
This solution is introducing a small curve adjustment making a dip in the mid to dark values as well as slightly decreasing saturation by a factor of 0.9.
<img width="1922" height="1315" alt="image" src="https://github.com/user-attachments/assets/a1c18973-e9de-425d-8d80-26e1f81a4143" />


V1 is before the change
V2 is after the change. It was recolored to compensate for the change in contrast.

<img width="1100" height="342" alt="image" src="https://github.com/user-attachments/assets/5c3c3693-41f5-443e-923f-eee17bea88f0" />
